### PR TITLE
Update pre-commit hook, dynamic version number

### DIFF
--- a/lib/githooks/pre-commit
+++ b/lib/githooks/pre-commit
@@ -80,7 +80,7 @@ dump_changed_files "${git_against}"
 
 # Lintball needs a list of files to be passed, removing the need to put double quotes
 #shellcheck disable=SC2086
-docker run -v "$PWD:/scan" -e DEBUG="true" --rm -i "lintball:1.0.0" ${CHANGED_FILES}
+docker run -v "$PWD:/scan" -e DEBUG="true" --rm -i "lintball:<[[ LINTBALL_VERSION ]]>" ${CHANGED_FILES}
 RC=$?
 
 echo "Docker Run RC=${RC}"


### PR DESCRIPTION
Need to use the dynamic version in the pre-commit hook, else recent fixes (like .yamllint parsing) won't be pulled in by the pre-commit hooks.